### PR TITLE
[FIX] Update Vite and Axios dependencies to fix vulnerabilities

### DIFF
--- a/pokecopilot-api/package-lock.json
+++ b/pokecopilot-api/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "pokecopilot",
+  "name": "pokecopilot-api",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "pokecopilot-api",
       "dependencies": {
         "@azure/openai": "^1.0.0-beta.12",
         "@langchain/community": "^0.2.13",
@@ -1128,9 +1129,10 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {

--- a/pokecopilot-client/package-lock.json
+++ b/pokecopilot-client/package-lock.json
@@ -7859,7 +7859,9 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "4.5.1",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
+      "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13662,7 +13664,9 @@
       "dev": true
     },
     "vite": {
-      "version": "4.5.1",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
+      "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
       "dev": true,
       "requires": {
         "esbuild": "^0.18.10",

--- a/pokecopilot-database/package-lock.json
+++ b/pokecopilot-database/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "pokecopilot-database",
       "dependencies": {
         "@azure/openai": "^1.0.0-beta.12",
         "@langchain/community": "^0.2.13",
@@ -1034,9 +1035,10 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",


### PR DESCRIPTION
This fixes #9 

Summary
`pokecopilot-api` (backend): Upgraded axios from 1.7.2 to v1.7.4
`pokecopilot-database` (database prep): Upgraded axios from 1.7.2 to v1.7.4
`pokecopilot-client` (frontend): Upgraded vite from v4.5.1 to v4.5.3
