### PR TITLE
[FIX] Upgrade download-artifact action to v4 

### DIFF
--- a/.github/workflows/main_dge4d54qzwwy2du-web.yml
+++ b/.github/workflows/main_dge4d54qzwwy2du-web.yml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: node-app
 


### PR DESCRIPTION

This resolves the arbitrary file write vulnerability of the actions/download-artifact v3 described in https://github.com/rjwignar/pokecopilot/security/dependabot/5